### PR TITLE
Explicitly mention Piwik 3 compatibility

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -10,7 +10,7 @@
     "license": "GPL v3+",
     "homepage": "https://github.com/JohnDeery/piwik_cache_buster",
     "require": {
-        "piwik": ">=2.2.0",
+        "piwik": ">=2.2.0,<4.0.0-b1",
         "php": ">=5.3.0"
     },
     "authors": [


### PR DESCRIPTION
Hi,

According to https://forum.piwik.org/t/cachebuster-und-piwik-3-2-1/26575 this plugin is working with Piwik 3 
It would be nice to mention this according to 
https://developer.piwik.org/guides/migrate-piwik-2-to-3#if-your-plugin-is-compatible-with-piwik-2-and-piwik-3